### PR TITLE
Make compile with newer deal.II

### DIFF
--- a/source/velocity_boundary_conditions/gplates.cc
+++ b/source/velocity_boundary_conditions/gplates.cc
@@ -252,9 +252,9 @@ namespace aspect
       {
         Point<3> internal_position;
         if (dim == 2)
-          internal_position = rotation_matrix * convert_tensor<dim,3>(position);
+          internal_position = Point<3> (rotation_matrix * convert_tensor<dim,3>(position));
         else
-          internal_position = convert_tensor<dim,3>(position);
+          internal_position = Point<3> (convert_tensor<dim,3>(position));
 
         // transform internal_position in spherical coordinates
         const std_cxx11::array<double,3> internal_position_in_spher_array =

--- a/tests/gplates_1_3/screen-output
+++ b/tests/gplates_1_3/screen-output
@@ -20,7 +20,7 @@
    Assuming constant boundary conditions for rest of model run.
 
 Number of active cells: 768 (on 4 levels)
-Number of degrees of freedom: 10.656 (6.528+864+3.264)
+Number of degrees of freedom: 10,656 (6,528+864+3,264)
 
 *** Timestep 0:  t=0 years
    Solving temperature system... 0 iterations.

--- a/tests/gplates_1_4/screen-output
+++ b/tests/gplates_1_4/screen-output
@@ -20,7 +20,7 @@
    Assuming constant boundary conditions for rest of model run.
 
 Number of active cells: 768 (on 4 levels)
-Number of degrees of freedom: 10.656 (6.528+864+3.264)
+Number of degrees of freedom: 10,656 (6,528+864+3,264)
 
 *** Timestep 0:  t=0 years
    Solving temperature system... 0 iterations.

--- a/tests/gplates_3d/screen-output
+++ b/tests/gplates_3d/screen-output
@@ -10,7 +10,7 @@
    Assuming constant boundary conditions for rest of model run.
 
 Number of active cells: 768 (on 2 levels)
-Number of degrees of freedom: 28.690 (20.790+970+6.930)
+Number of degrees of freedom: 28,690 (20,790+970+6,930)
 
 *** Timestep 0:  t=0 years
    Solving temperature system... 0 iterations.

--- a/tests/gplates_rotation/screen-output
+++ b/tests/gplates_rotation/screen-output
@@ -20,7 +20,7 @@
    Assuming constant boundary conditions for rest of model run.
 
 Number of active cells: 768 (on 4 levels)
-Number of degrees of freedom: 10.656 (6.528+864+3.264)
+Number of degrees of freedom: 10,656 (6,528+864+3,264)
 
 *** Timestep 0:  t=0 years
    Solving temperature system... 0 iterations.


### PR DESCRIPTION
@ebredow: I needed to include these changes in your PR to make it compile with my development version of deal.II. Can you merge this into your pull request?
@bangerth: It seems I can no longer assign a Tensor<1,dim> to a Point, but I can construct a Point from a Tensor<1,dim>, was this change done by purpose? If not, should I prepare a patch with an overloaded assignment operator for point?
