### PR TITLE
Flexible gplates velocities

### DIFF
--- a/include/aspect/velocity_boundary_conditions/gplates.h
+++ b/include/aspect/velocity_boundary_conditions/gplates.h
@@ -57,9 +57,9 @@ namespace aspect
           /**
            * Outputs the GPlates module information at model start.
            */
-          void screen_output(const Tensor<1,2> &surface_point_one,
-                             const Tensor<1,2> &surface_point_two,
-                             const ConditionalOStream &pcout) const;
+          std::string
+          screen_output(const Tensor<1,2> &surface_point_one,
+                        const Tensor<1,2> &surface_point_two) const;
 
           /**
            * Loads a gplates .gpml velocity file. Throws an exception if the
@@ -137,8 +137,12 @@ namespace aspect
           Tensor<1,3>
           cartesian_surface_coordinates(const Tensor<1,3> &sposition) const;
 
+          /**
+           * This function looks up the north- and east-velocities at a given
+           * position and converts them to cartesian velocities.
+           */
           Tensor<1,dim>
-          cartesian_velocity_from_spherical_point(const std_cxx11::array<double,3> &spherical_point) const;
+          cartesian_velocity_at_surface_point(const std_cxx11::array<double,3> &spherical_point) const;
 
           /**
            * Returns cartesian velocities calculated from surface velocities

--- a/include/aspect/velocity_boundary_conditions/gplates.h
+++ b/include/aspect/velocity_boundary_conditions/gplates.h
@@ -137,6 +137,9 @@ namespace aspect
           Tensor<1,3>
           cartesian_surface_coordinates(const Tensor<1,3> &sposition) const;
 
+          Tensor<1,dim>
+          cartesian_velocity_from_spherical_point(const std_cxx11::array<double,3> &spherical_point) const;
+
           /**
            * Returns cartesian velocities calculated from surface velocities
            * and position in spherical coordinates

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -52,9 +52,18 @@ namespace aspect
       std_cxx11::array<double,dim> scoord;
 
       scoord[0] = position.norm(); // R
-      scoord[1] = std::atan2(position(1),position(0)); // Phi
+
+      // Phi, we define phi at the poles and the origin as 0.0
+      if ((std::abs(position(1)) <= std::numeric_limits<double>::min())
+          && (std::abs(position(0)) <= std::numeric_limits<double>::min()))
+        scoord[1] = 0.0;
+      else
+        scoord[1] = std::atan2(position(1),position(0));
+
       if (scoord[1] < 0.0)
         scoord[1] += 2.0*numbers::PI; // correct phi to [0,2*pi]
+
+      // Theta, we define theta at the origin as 0.0
       if (dim==3)
         {
           if (scoord[0] > std::numeric_limits<double>::min())


### PR DESCRIPTION
Ok, last try for a working interpolation algorithm. Please take a look if this looks reasonable at the poles for all of your models (current_day, theta_test, phi_test). Phi test and theta test may still have strange velocities at one point directly at the pole, but not longer in this large area, and that is ok, because they are artificial tests anyway (I did not compute these velocities with GPlates, but wrote the file myself, GPlates would have probably output different velocities directly at the poles). The current_day test looks good for me. The velocities in the test are even a bit smaller now on my machine. I also did some cleanup, but dont get confused, the only real change is in the surface_velocity, and the new cartesian_velocity_at_surface_point function.
